### PR TITLE
Improve ftl-build cache reuse with multi-stage Dockerfile

### DIFF
--- a/.github/workflows/ftl-build.yml
+++ b/.github/workflows/ftl-build.yml
@@ -14,7 +14,7 @@ on:
     - cron: "30 1 * * 0"
 
 env:
-  DOCKER_REGISTRY_IMAGE: ${{ secrets.DOCKERHUB_NAMESPACE }}/ftl-build
+  DOCKER_REGISTRY_IMAGE: ${{ vars.DOCKERHUB_NAMESPACE }}/ftl-build
   GITHUB_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/ftl-build
 
 permissions:

--- a/ftl-build/Dockerfile
+++ b/ftl-build/Dockerfile
@@ -1,12 +1,16 @@
-FROM alpine:3.23 AS build
-
-ARG TARGETPLATFORM
 ARG readlineversion=8.3
 ARG termcapversion=1.3.1-patched
 ARG nettleversion=3.10.2
 ARG mbedtlsversion=4.0.0
+# lastet master commit
+ARG libbacktraceversion=96664e69b1ecdb76e824be1d9e8f475b76dd08cf
+# unreleased changes post v1.13.0
+ARG batsversion=d9faff0d7bc32e7adebc6552446f978118d3ab3b
 
-RUN apk add --no-cache \
+FROM alpine:3.23 AS base
+
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add \
         alpine-sdk \
         bash \
         bind-tools \
@@ -44,11 +48,10 @@ RUN apk add --no-cache \
         xxd \
         zip
 
-ENV STATIC=true
-ENV TEST=true
-
 # As of Alpine 3.21 (Dec 2024), we need to patch the termcap library to include
 # the standard headers as well as unistd.h for the write function
+FROM base AS termcap-build
+ARG termcapversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz | tar -xz \
     && cd termcap-${termcapversion} \
     && ./configure --enable-static --disable-shared --disable-doc --without-examples \
@@ -59,6 +62,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/termcap-${termcapversion}.tar.gz
     && cd .. \
     && rm -r termcap-${termcapversion}
 
+FROM base AS readline-build
+ARG readlineversion
+COPY --from=termcap-build /usr/local/ /usr/local/
 RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.gz | tar -xz \
     && cd readline-${readlineversion} \
     && ./configure --enable-static --disable-shared --disable-install-examples \
@@ -68,6 +74,8 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/readline-${readlineversion}.tar.
     && cd .. \
     && rm -r readline-${readlineversion}
 
+FROM base AS nettle-build
+ARG nettleversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz | tar -xz \
     && cd nettle-${nettleversion} \
     && ./configure --enable-static --disable-shared --disable-openssl --disable-mini-gmp -disable-gcov --disable-documentation \
@@ -78,6 +86,9 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/nettle-${nettleversion}.tar.gz |
 # Build static mbedTLS with pthread support
 # Disable AESNI on linux/386 asit would possibly result in an incompatible
 # binary in processors lacking the AESNI and SSE2 instruction sets
+FROM base AS mbedtls-build
+ARG TARGETPLATFORM
+ARG mbedtlsversion
 RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz2 | tar -xj \
     && cd mbedtls-${mbedtlsversion} \
     && sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' tf-psa-crypto/include/psa/crypto_config.h \
@@ -93,15 +104,32 @@ RUN curl -sSL https://ftl.pi-hole.net/libraries/mbedtls-${mbedtlsversion}.tar.bz
     && rm -r mbedtls-${mbedtlsversion}
 
 # Build static libbacktrace
-RUN git clone https://github.com/ianlancetaylor/libbacktrace.git \
-    && cd libbacktrace \
+FROM base AS libbacktrace-build
+ARG libbacktraceversion
+RUN curl -sSL https://github.com/ianlancetaylor/libbacktrace/archive/${libbacktraceversion}.tar.gz | tar -xz \
+    && cd libbacktrace-${libbacktraceversion} \
     && ./configure --enable-static --disable-shared \
     && make -j $(nproc) install \
     && cd .. \
-    && rm -r libbacktrace
+    && rm -r libbacktrace-${libbacktraceversion}
 
 # Install bats-core directly into the build image
-RUN git clone https://github.com/bats-core/bats-core.git
+FROM base AS bats-build
+ARG batsversion
+RUN curl -sSL https://github.com/bats-core/bats-core/archive/${batsversion}.tar.gz | tar -xz \
+    && mv bats-core-${batsversion} bats-core
+
+FROM base AS build
+
+ENV STATIC=true
+ENV TEST=true
+
+COPY --link --from=termcap-build /usr/local/ /usr/local/
+COPY --link --from=readline-build /usr/local/ /usr/local/
+COPY --link --from=nettle-build /usr/local/ /usr/local/
+COPY --link --from=mbedtls-build /usr/local/ /usr/local/
+COPY --link --from=libbacktrace-build /usr/local/ /usr/local/
+COPY --link --from=bats-build /bats-core /bats-core
 
 ENV BATS=/bats-core/bin/bats
 


### PR DESCRIPTION
## Summary

- Split the single `build` stage into isolated per-library stages (`termcap`, `readline`, `nettle`, `mbedTLS`, `libbacktrace`, `bats`) — bumping one version ARG only invalidates that stage and its corresponding `COPY --link` layer in the final `build` stage
- Version-pin `libbacktrace` and `bats-core` via ARG; both now download via `curl` tarball (no git, no history, no `.git` directory) consistent with the other libraries
- Add `--link` to all `COPY --from` in the `build` stage so each assembly layer is independently cacheable
- Switch `apk add --no-cache` to `--mount=type=cache,target=/var/cache/apk` so packages are cached by BuildKit between rebuilds without bloating the image

## Test plan

- [ ] Verify library stages all compile and assemble correctly
- [ ] Verify full FTL build + test suite passes
- [ ] Bump a single version ARG and confirm only that stage rebuilds (cache hit on all others)
- [ ] Verify multi-platform build still works via CI